### PR TITLE
base: Add envkernel to base image

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -61,6 +61,9 @@ RUN \
         # Requires nbgrader>6
         # voila \
         && \
+    pip install --no-cache-dir \
+        envkernel \
+	&& \
     jupyter contrib nbextension install --sys-prefix && \
     python -m bash_kernel.install --sys-prefix && \
     ln -s /notebooks /home/jovyan/notebooks && \


### PR DESCRIPTION
Add envkernel, could be useful in setting up other environments including PATH.

Making a separate PR, so that we can add it only when we are ready to regenerate the base image.