### PR TITLE
Add cmdstan for bayesda2022

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ VER_STD=5.0.10
 # Julia
 VER_JULIA=5.0.0
 # R
-VER_R=5.0.12-bayesda2022
+VER_R=5.0.12-bayesda2022.1
 # OpenCV
 VER_CV=1.8.0
 

--- a/r-ubuntu.Dockerfile
+++ b/r-ubuntu.Dockerfile
@@ -348,6 +348,14 @@ RUN \
     Rscript -e "library('aaltobda')" && \
     fix-permissions /usr/local/lib/R/site-library && \
     clean-layer.sh
+# bayesdata2022, RT#22158
+RUN \
+    Rscript -e "library(cmdstanr) ; install_cmdstan()" && \
+    mv ~/.cmdstan/ /opt/cmdstan/ && \
+    fix-permissions /opt/cmdstan/ && \
+    clean-layer.sh
+"
+
 
 # ====================================
 


### PR DESCRIPTION
This is one option, but I would propose that instead it be added to `/coursedata/` so that it can be managed more dynamically... opening this as a pull of concept since I did it before thinking of the other option.
