### PR TITLE
base: Disable announcement extension

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -130,6 +130,9 @@ RUN \
     jupyter serverextension disable jupyter_lsp && \
     clean-layer.sh
 
+RUN \
+    jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
+
 # Hooks and scripts are also copied at the end of other Dockerfiles because
 # they might update frequently
 COPY --chmod=0755 hooks/ scripts/ /usr/local/bin/

--- a/standard.Dockerfile
+++ b/standard.Dockerfile
@@ -145,6 +145,9 @@ RUN \
         && \
     clean-layer.sh
 
+RUN \
+    jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
+
 # ========================================
 
 # Duplicate of base, but hooks can update frequently and are small so


### PR DESCRIPTION
As Jupyterlab documentation says:
> The frontend plugin requesting the news and checking for the update is `@jupyterlab/apputils-extension:announcements`. It can be disabled as any plugin by executing in a terminal prior to start JupyterLab.